### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/RyanMorash/aionatgrid/security/code-scanning/1](https://github.com/RyanMorash/aionatgrid/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow or individual jobs, granting only the minimal scopes needed. For a typical CI workflow that just checks out code and runs lint/tests, `contents: read` is sufficient, and can safely be set at the workflow root so all jobs inherit it.

For this specific file, the best fix without changing functionality is to add a top-level `permissions` section after the `on:` block. Both `lint` and `test` only read the repository contents (via `actions/checkout`) and run commands; they do not need to write to the repository or interact with issues or pull requests. Therefore, we can add:

```yaml
permissions:
  contents: read
```

This will apply to all jobs that do not override `permissions` (both `lint` and `test` here) and will restrict the `GITHUB_TOKEN` accordingly. No imports, methods, or additional definitions are needed, since this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration permissions.

**Note:** This is an internal infrastructure update with no impact on user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->